### PR TITLE
Remove dependence on sklearn.linear_model.base.

### DIFF
--- a/sindy/feature_library/custom_library.py
+++ b/sindy/feature_library/custom_library.py
@@ -64,7 +64,7 @@ class CustomLibrary(BaseFeatureLibrary):
         -------
         output_feature_names : list of string, length n_output_features
         """
-        check_is_fitted(self, "n_input_features_")
+        check_is_fitted(self)
         if input_features is None:
             input_features = ["x%d" % i for i in range(self.n_input_features_)]
         feature_names = []
@@ -103,7 +103,7 @@ class CustomLibrary(BaseFeatureLibrary):
             The matrix of features, where NP is the number of features
             generated from applying the custom functions to the inputs.
         """
-        check_is_fitted(self, ["n_input_features_", "n_output_features_"])
+        check_is_fitted(self)
 
         X = check_array(X)
 

--- a/sindy/feature_library/fourier_library.py
+++ b/sindy/feature_library/fourier_library.py
@@ -59,7 +59,7 @@ class FourierLibrary(BaseFeatureLibrary):
         -------
         output_feature_names : list of string, length n_output_features
         """
-        check_is_fitted(self, "n_input_features_")
+        check_is_fitted(self)
         if input_features is None:
             input_features = ["x%d" % i for i in range(self.n_input_features_)]
         feature_names = []
@@ -106,7 +106,7 @@ class FourierLibrary(BaseFeatureLibrary):
             The matrix of features, where NP is the number of Fourier
             features generated from the inputs.
         """
-        check_is_fitted(self, ["n_input_features_", "n_output_features_"])
+        check_is_fitted(self)
 
         X = check_array(X)
 

--- a/sindy/feature_library/polynomial_library.py
+++ b/sindy/feature_library/polynomial_library.py
@@ -9,9 +9,7 @@ from sklearn.preprocessing import _csr_polynomial_expansion
 
 from sindy.feature_library import BaseFeatureLibrary
 
-# TODO
-# -Check if order or base classes needs to be swapped
-# -Tell Kathleen about black
+
 class PolynomialLibrary(PolynomialFeatures, BaseFeatureLibrary):
     """
     Generate polynomial and interaction features. This is the same as
@@ -64,7 +62,7 @@ class PolynomialLibrary(PolynomialFeatures, BaseFeatureLibrary):
 
     @property
     def powers_(self):
-        check_is_fitted(self, "n_input_features_")
+        check_is_fitted(self)
 
         combinations = self._combinations(
             self.n_input_features_,
@@ -154,7 +152,7 @@ class PolynomialLibrary(PolynomialFeatures, BaseFeatureLibrary):
             The matrix of features, where NP is the number of polynomial
             features generated from the combination of inputs.
         """
-        check_is_fitted(self, ["n_input_features_", "n_output_features_"])
+        check_is_fitted(self)
 
         X = check_array(X, order="F", dtype=FLOAT_DTYPES, accept_sparse=("csr", "csc"))
 

--- a/sindy/optimizers/base.py
+++ b/sindy/optimizers/base.py
@@ -5,13 +5,28 @@ Base class for SINDy optimizers.
 import abc
 
 import numpy as np
-from sklearn.base import RegressorMixin
-from sklearn.linear_model.base import LinearModel
+from scipy import sparse
+from sklearn.linear_model import LinearRegression
 from sklearn.utils.validation import check_X_y
-from sklearn.linear_model.base import _rescale_data
+from sklearn.utils.extmath import safe_sparse_dot
 
 
-class BaseOptimizer(LinearModel, RegressorMixin):
+def _rescale_data(X, y, sample_weight):
+    """Rescale data so as to support sample_weight"""
+    n_samples = X.shape[0]
+    sample_weight = np.asarray(sample_weight)
+    if sample_weight.ndim == 0:
+        sample_weight = np.full(n_samples, sample_weight,
+                                dtype=sample_weight.dtype)
+    sample_weight = np.sqrt(sample_weight)
+    sw_matrix = sparse.dia_matrix((sample_weight, 0),
+                                  shape=(n_samples, n_samples))
+    X = safe_sparse_dot(sw_matrix, X)
+    y = safe_sparse_dot(sw_matrix, y)
+    return X, y
+
+
+class BaseOptimizer(LinearRegression):
     """
     Base class for SINDy optimizers. Subclasses must implement
     a _reduce method for carrying out the bulk of the work of
@@ -33,9 +48,14 @@ class BaseOptimizer(LinearModel, RegressorMixin):
     """
 
     def __init__(self, normalize=False, fit_intercept=False, copy_X=True):
-        self.fit_intercept = fit_intercept
-        self.normalize = normalize
-        self.copy_X = copy_X
+        super(BaseOptimizer, self).__init__(
+            fit_intercept=fit_intercept,
+            normalize=normalize,
+            copy_X=copy_X
+        )
+        # self.fit_intercept = fit_intercept
+        # self.normalize = normalize
+        # self.copy_X = copy_X
         self.iters = 0
         self.coef_ = []
         self.ind_ = []


### PR DESCRIPTION
Changed `BaseOptimizer` class so that it inherits from `sklearn.linear_model.LinearRegression` instead of `sklearn.linear_model.base.LinearModel`. sklearn was throwing a warning that we won't be able to import from `sklearn.linear_model.base` in the future, i.e.
 
```/home2/bdesilva/.local/lib/python3.6/site-packages/sklearn/utils/deprecation.py:144
  /home2/bdesilva/.local/lib/python3.6/site-packages/sklearn/utils/deprecation.py:144: FutureWarning: The sklearn.linear_model.base module is  deprecated in version 0.22 and will be removed in version 0.24. The corresponding classes / functions should instead be imported from sklearn.linear_model. Anything that cannot be imported from sklearn.linear_model is now part of the private API.
    warnings.warn(message, FutureWarning)
```

I also

- Added sklearn's `_rescale_data` function which we were also previously importing from `sklearn.linear_model.base`
- Removed `attribute` argument being passed to `check_is_fitted` as it is being deprecated
- Removed extraneous code from `sindy.utils.base` that was also using `LinearRegression`
- Reformatted `sindy.utils.base` with black
- Updated string formatting in `sindy.utils.base`